### PR TITLE
Refactored RequestVerb enums to resolve DELETE redefinition on Windows

### DIFF
--- a/src/accounts/accounts.cpp
+++ b/src/accounts/accounts.cpp
@@ -10,7 +10,7 @@ namespace accounts {
         std::string target = "/accounts/";
         target += accountId;
         target += "/ledger";
-        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::GET);
+        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::E_GET);
 
         std::vector<responses::entry> entries;
         for (const auto &item : resp) {
@@ -25,7 +25,7 @@ namespace accounts {
         const auto &httpClient = auth.getHttpClientPtr();
 
         std::string target = "/accounts";
-        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::GET);
+        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::E_GET);
 
         std::vector<responses::account> accounts;
         for (const auto &item : resp) {
@@ -40,7 +40,7 @@ namespace accounts {
         const auto &httpClient = auth.getHttpClientPtr();
         std::string target = "/accounts/";
         target += accountId;
-        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::GET);
+        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::E_GET);
 
         responses::account account(resp);
         return account;
@@ -52,7 +52,7 @@ namespace accounts {
         std::string target = "/accounts/";
         target += accountId;
         target += "/holds";
-        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::GET);
+        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::E_GET);
 
         std::vector<responses::hold> holds;
         for (const auto &item : resp) {

--- a/src/orders/orders.cpp
+++ b/src/orders/orders.cpp
@@ -19,7 +19,7 @@ namespace orders {
             target += productId;
         }
 
-        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::DELETE);
+        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::E_DELETE);
         return !resp.get_optional<bool>("error");
 
     }
@@ -34,7 +34,7 @@ namespace orders {
         }
 
         std::vector<std::string> orders;
-        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::DELETE);
+        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::E_DELETE);
         for (auto &order : resp) {
             orders.push_back(order.second.data());
         }
@@ -89,7 +89,7 @@ namespace orders {
         auto jsonBody = jsonStream.str();
         boost::replace_all(jsonBody, "\n", "");
 
-        auto resp = httpClient->makeRequest(target, jsonBody, HttpClient::RequestVerb::POST);
+        auto resp = httpClient->makeRequest(target, jsonBody, HttpClient::RequestVerb::E_POST);
         responses::order order(resp);
         return order;
     }
@@ -156,7 +156,7 @@ namespace orders {
         auto jsonBody = jsonStream.str();
         boost::replace_all(jsonBody, "\n", "");
 
-        auto resp = httpClient->makeRequest(target, jsonBody, HttpClient::RequestVerb::POST);
+        auto resp = httpClient->makeRequest(target, jsonBody, HttpClient::RequestVerb::E_POST);
         responses::order order(resp);
         return order;
     }
@@ -189,7 +189,7 @@ namespace orders {
         }
 
         std::vector<responses::order> orders;
-        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::GET);
+        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::E_GET);
         for (const auto &ord : resp) {
             responses::order order(ord.second);
             orders.push_back(order);
@@ -207,7 +207,7 @@ namespace orders {
             target += "client:";
         }
         target += orderId;
-        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::GET);
+        auto resp = httpClient->makeRequest(target, "", HttpClient::RequestVerb::E_GET);
         responses::order order(resp);
         return order;
     }

--- a/src/util/httpclient.cpp
+++ b/src/util/httpclient.cpp
@@ -36,10 +36,10 @@ pt::ptree
 HttpClient::makeRequest(const std::string &target, const std::string &body, HttpClient::RequestVerb rv) {
     http::verb boostVerb;
     std::string messageVerb;
-    if (rv == HttpClient::RequestVerb::GET) {
+    if (rv == HttpClient::RequestVerb::E_GET) {
         messageVerb = "GET";
         boostVerb = http::verb::get;
-    } else if (rv == HttpClient::RequestVerb::POST) {
+    } else if (rv == HttpClient::RequestVerb::E_POST) {
         messageVerb = "POST";
         boostVerb = http::verb::post;
     } else {


### PR DESCRIPTION
When compiling this on Windows with CMAKE I encountered an error since DELETE is already defined as a macro in winnt.h. The change I proposed here is just refactoring GET, POST, DELETE to allow it to compile.